### PR TITLE
Improve code quality in entrypoint

### DIFF
--- a/shcf_init.sh
+++ b/shcf_init.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 ## ---------------------------------------
 ## https://github.com/shsdk/shcf/issues/20
@@ -7,11 +7,11 @@
 
 ## Is it a symlink? readlink binary would tell us, silence means it is NOT a symlink
 ##
-actual_file=$(readlink $0)
+actual_file=$(readlink "$0")
 
-bootpath=$(dirname $0)
-[[ "$actual_file" != "" ]] && bootpath=$(dirname $actual_file)
+bootpath=$(dirname $"0")
+[[ "$actual_file" != "" ]] && bootpath=$(dirname "$actual_file")
 
 ## Assemble the fullpath
 ##
-${bootpath}/core/bin/shcf_cli init
+"${bootpath}/core/bin/shcf_cli" init


### PR DESCRIPTION
This:

- Quotes arguments so the program worked when any parent directory has a name with whitespace
- Uses `/usr/bin/env bash` as shebang because some systems don't have bash located in `/bin`

Related to #22